### PR TITLE
pyproject.toml, uv, and hpc3 setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ Building Flash-X in AMReX mode requires that Message Passing Interface (MPI) lib
 Organization of computational experiments is implemented using Jobrunner, which enables reuse of files/scripts along directory trees and ensures strict organization rules. Details on Jobrunner are provided separately in its own repository (https://github.com/Lab-Notebooks/Jobrunner), and can be installed by running,
 
 ```
-pip install -r requirements.txt --user --upgrade
+uv venv
+source .venv/bin/activate
+uv sync
 ```
 
-`pip` should point to Python3.8+ package installer `pip3`
+`uv` manages the Python 3.8+ environment and installs Jobrunner/BoxKit/click from `pyproject.toml`.
 
 Software dependencies for this notebook are divided into two categories: 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "flash-x-development"
+version = "0.0.0"
+description = "Laboratory notebook and execution environment for Flash-X experiments"
+requires-python = ">=3.8,<3.12"
+dependencies = [
+    "click",
+    "boxkit",
+    "pyjobrunner",
+    # pyjobrunner imports pkg_resources (jobrunner/cli/_jobrunner.py) but doesn't
+    # declare setuptools as a dependency itself. setuptools>=82 dropped pkg_resources.
+    "setuptools<82",
+]
+
+[tool.uv]
+package = false
+
+[tool.uv.sources]
+boxkit = { git = "https://github.com/Box-Tools/BoxKit.git", branch = "main" }
+pyjobrunner = { git = "https://github.com/Lab-Notebooks/Jobrunner.git", tag = "2024.08" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-click
-git+ssh://git@github.com/Box-Tools/BoxKit.git@main
-git+ssh://git@github.com/Lab-Notebooks/Jobrunner.git@2024.08

--- a/sites/hpc3/environment.sh
+++ b/sites/hpc3/environment.sh
@@ -4,17 +4,14 @@ export OMP_NUM_THREADS=1
 export UCX_TLS=rc,mm
 export UCX_NET_DEVICES=mlx5_0:1
 
-# Load GCC openmpi and python
+# Load GCC and openmpi
 module load gcc/11.2.0
 module load openmpi/5.0.1/gcc.11.2.0
-module load anaconda/2024.06
 
-. /opt/apps/anaconda/2024.06/etc/profile.d/conda.sh
-conda activate flashx
+source $PROJECT_HOME/.venv/bin/activate
 
 # Set MPI_HOME by quering path loaded by site module
 export MPI_HOME=$(which mpicc | sed s/'\/bin\/mpicc'//)
-
 
 # Load HDF5 module in desired configuration if available. If not specified
 # the HDF5 will be built when setting up software

--- a/sites/hpc3/setup.sbatch
+++ b/sites/hpc3/setup.sbatch
@@ -1,0 +1,27 @@
+#!/bin/bash
+#SBATCH --job-name=fx-setup
+#SBATCH --partition=standard
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=8
+#SBATCH --time=04:00:00
+#SBATCH --output=setup-%j.out
+#SBATCH --error=setup-%j.err
+
+# Run `./configure -s hpc3` once beforehand so config.sh exists, then submit
+# from the project root, e.g.:
+#   sbatch sites/hpc3/setup.sbatch software/amrex software/flashx software/flashkit software/hdf5
+#   sbatch sites/hpc3/setup.sbatch simulation/RisingBubble
+
+set -e
+
+cd "$SLURM_SUBMIT_DIR"
+
+source .venv/bin/activate
+
+DIRLIST=("$@")
+if [ ${#DIRLIST[@]} -eq 0 ]; then
+    DIRLIST=(software/amrex software/flashx software/hdf5)
+fi
+
+jobrunner setup "${DIRLIST[@]}" --verbose --exit-on-failure


### PR DESCRIPTION
1. replaces requirements.txt with pyproject.toml, and says to use `uv` in README.md. 
2. Updates the hpc3 site setup to source from .venv instead of using conda.